### PR TITLE
修复LoadBalancingDriver.connect对不支持连接的处理逻辑错误

### DIFF
--- a/src/main/java/com/tidb/jdbc/LoadBalancingDriver.java
+++ b/src/main/java/com/tidb/jdbc/LoadBalancingDriver.java
@@ -262,6 +262,10 @@ public class LoadBalancingDriver implements Driver {
 
   @Override
   public Connection connect(final String tidbUrl, final Properties info) throws SQLException {
+    // The driver should return "null" if it realizes it is the wrong kind of driver to connect to the given URL.
+    if (!acceptsURL(tidbUrl)) {
+      return null;
+    }
     String mysqlUrl = getMySqlUrl(tidbUrl);
     Function<Backend, String[]> mapper = createUrlsMapper();
     if(mapper != null){

--- a/src/main/java/com/tidb/jdbc/impl/DiscovererImpl.java
+++ b/src/main/java/com/tidb/jdbc/impl/DiscovererImpl.java
@@ -35,10 +35,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Logger;
 
 public class DiscovererImpl implements Discoverer {
-  private static final Logger logger = Logger.getLogger(DiscovererImpl.class.getName());
 
   private static final String QUERY_TIDB_SERVER_SQL =
       "SELECT `IP`,`PORT` FROM `INFORMATION_SCHEMA`.`TIDB_SERVERS_INFO` ORDER BY `IP`";
@@ -152,7 +150,6 @@ public class DiscovererImpl implements Discoverer {
         if (failedBackends.containsKey(tidbUrl)) {
           continue;
         }
-        logger.fine("tidbUrl:" + tidbUrl);
         result = discover(tidbUrl, info);
         if (result.isOk()) {
           return result.unwrap();
@@ -163,7 +160,6 @@ public class DiscovererImpl implements Discoverer {
       }
 
       if (finalTry != null) {
-        logger.fine("tidbUrl:" + finalTry);
         result = discover(finalTry, info);
         if (result.isOk()) {
           return result.unwrap();

--- a/src/main/java/com/tidb/jdbc/impl/DiscovererImpl.java
+++ b/src/main/java/com/tidb/jdbc/impl/DiscovererImpl.java
@@ -35,8 +35,10 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
 
 public class DiscovererImpl implements Discoverer {
+  private static final Logger logger = Logger.getLogger(DiscovererImpl.class.getName());
 
   private static final String QUERY_TIDB_SERVER_SQL =
       "SELECT `IP`,`PORT` FROM `INFORMATION_SCHEMA`.`TIDB_SERVERS_INFO` ORDER BY `IP`";
@@ -150,7 +152,7 @@ public class DiscovererImpl implements Discoverer {
         if (failedBackends.containsKey(tidbUrl)) {
           continue;
         }
-        System.out.println("tidbUrl:"+tidbUrl);
+        logger.fine("tidbUrl:" + tidbUrl);
         result = discover(tidbUrl, info);
         if (result.isOk()) {
           return result.unwrap();
@@ -161,7 +163,7 @@ public class DiscovererImpl implements Discoverer {
       }
 
       if (finalTry != null) {
-        System.out.println("tidbUrl:"+finalTry);
+        logger.fine("tidbUrl:" + finalTry);
         result = discover(finalTry, info);
         if (result.isOk()) {
           return result.unwrap();

--- a/src/test/java/com/tidb/jdbc/TiDBDriverTest.java
+++ b/src/test/java/com/tidb/jdbc/TiDBDriverTest.java
@@ -18,6 +18,7 @@ package com.tidb.jdbc;
 
 import com.tidb.jdbc.impl.*;
 
+import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Arrays;
@@ -27,6 +28,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 
 import com.tidb.test.IntegrationTest;
+import io.tidb.bigdata.jdbc.TiDBDriver;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -290,5 +292,21 @@ public class TiDBDriverTest {
     Assert.assertArrayEquals(discoverer.getAndReload(), backends3);
     config.unblock();
     Assert.assertArrayEquals(discoverer.reload().get(), backends3);
+  }
+
+  /**
+   * connect方法应该先判断连接是否支持，不支持的话返回null
+   * <p>
+   *     背景：我们的某个模块中引入了多个jdbc依赖（tidb-loadbalance/clickhouse-jdbc），
+   *     在尝试使用DriverManager.getConnection("jdbc:clickhouse://...")获取连接的时候，
+   *     tidb-loadbalance抛出了异常
+   * </p>
+   * @throws SQLException
+   */
+  @Test
+  public void testUnAcceptableUrl() throws SQLException {
+    TiDBDriver driver = new TiDBDriver();
+    Connection connection = driver.connect(ORACLE_URL, new Properties());
+    Assert.assertNull( "", null);
   }
 }


### PR DESCRIPTION
这个PR主要是解决了`LoadBalancingDriver.connect`在传入url是其他驱动的连接时没有返回null的问题。同时也把部分`System.out.println`打印的日志修改为用`JUL`输出